### PR TITLE
Refactor Cache Management to Use CacheSettingsService

### DIFF
--- a/backend/Lithuaningo.API/Models/CacheSettingEntity.cs
+++ b/backend/Lithuaningo.API/Models/CacheSettingEntity.cs
@@ -1,0 +1,22 @@
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Models;
+
+namespace Lithuaningo.API.Models
+{
+    [Table("cache_settings")]
+    public class CacheSettingEntity : BaseModel
+    {
+        [PrimaryKey("id")]
+        [Column("id")]
+        public Guid Id { get; set; }
+
+        [Column("key")]
+        public string Key { get; set; } = string.Empty;
+
+        [Column("value_minutes")]
+        public int ValueMinutes { get; set; }
+
+        [Column("description")]
+        public string? Description { get; set; }
+    }
+}

--- a/backend/Lithuaningo.API/Program.cs
+++ b/backend/Lithuaningo.API/Program.cs
@@ -95,10 +95,10 @@ static X509Certificate2? LoadCertificate(IWebHostEnvironment environment, IConfi
 }
 
 // Configure caching
-builder.Services.Configure<CacheSettings>(builder.Configuration.GetSection("CacheSettings"));
 builder.Services.AddMemoryCache(); // Use in-memory cache instead of Redis
 builder.Services.AddScoped<ICacheService, InMemoryCacheService>();
 builder.Services.AddScoped<CacheInvalidator>(); // Register the cache invalidator
+builder.Services.AddScoped<ICacheSettingsService, CacheSettingsService>(); // Register the cache settings service
 
 // Use NewtonsoftJson instead of the default System.Text.Json with secure settings
 builder.Services.AddControllers()

--- a/backend/Lithuaningo.API/Services/Cache/CacheSettingsService.cs
+++ b/backend/Lithuaningo.API/Services/Cache/CacheSettingsService.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading.Tasks;
+using Lithuaningo.API.Models;
+using Lithuaningo.API.Services.Supabase;
+using Microsoft.Extensions.Caching.Memory;
+using Supabase;
+using static Supabase.Postgrest.Constants;
+
+namespace Lithuaningo.API.Services.Cache
+{
+    public class CacheSettingsService : ICacheSettingsService
+    {
+        private readonly Client _supabaseClient;
+        private readonly IMemoryCache _memoryCache;
+        private readonly ILogger<CacheSettingsService> _logger;
+        private const string CacheKeyPrefix = "cache-settings:";
+        private const string DefaultCacheSetting = "default";
+        private const string FlashcardCacheSetting = "flashcard";
+        private const string LeaderboardCacheSetting = "leaderboard";
+        private const string AppInfoCacheSetting = "app_info";
+        private readonly TimeSpan _cacheExpiration = TimeSpan.FromMinutes(60);
+
+        public CacheSettingsService(
+            ISupabaseService supabaseService,
+            IMemoryCache memoryCache,
+            ILogger<CacheSettingsService> logger)
+        {
+            _supabaseClient = supabaseService.Client;
+            _memoryCache = memoryCache;
+            _logger = logger;
+        }
+
+        public async Task<CacheSettings> GetCacheSettingsAsync()
+        {
+            try
+            {
+                // Try to get from memory cache first
+                var cacheKey = $"{CacheKeyPrefix}all";
+                if (_memoryCache.TryGetValue(cacheKey, out CacheSettings? cachedSettings))
+                {
+                    _logger.LogDebug("Retrieved cache settings from memory cache");
+                    return cachedSettings!;
+                }
+
+                // Create settings object to populate
+                var settings = new CacheSettings();
+
+                // Get default setting
+                var defaultSetting = await GetSettingValueAsync(DefaultCacheSetting, 10);
+                settings.DefaultExpirationMinutes = defaultSetting;
+
+                // Get specific settings with fallback to default
+                settings.FlashcardCacheMinutes = await GetSettingValueAsync(FlashcardCacheSetting, defaultSetting);
+                settings.LeaderboardCacheMinutes = await GetSettingValueAsync(LeaderboardCacheSetting, defaultSetting);
+                settings.AppInfoCacheMinutes = await GetSettingValueAsync(AppInfoCacheSetting, defaultSetting);
+
+                // Cache the result in memory cache
+                _memoryCache.Set(cacheKey, settings, _cacheExpiration);
+
+                return settings;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving cache settings, using defaults");
+                return GetDefaultSettings();
+            }
+        }
+
+        private async Task<int> GetSettingValueAsync(string key, int defaultValue)
+        {
+            try
+            {
+                var query = _supabaseClient
+                    .From<CacheSettingEntity>()
+                    .Filter("key", Operator.Equals, key)
+                    .Select("value_minutes");
+
+                var result = await query.Get();
+                var setting = result.Models?.FirstOrDefault();
+
+                if (setting == null)
+                {
+                    _logger.LogWarning("Cache setting '{Key}' not found, using default value", key);
+                    return defaultValue;
+                }
+
+                return setting.ValueMinutes;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving cache setting '{Key}', using default value", key);
+                return defaultValue;
+            }
+        }
+
+        private CacheSettings GetDefaultSettings()
+        {
+            return new CacheSettings
+            {
+                DefaultExpirationMinutes = 10,
+                FlashcardCacheMinutes = 5,
+                LeaderboardCacheMinutes = 2,
+                AppInfoCacheMinutes = 5
+            };
+        }
+    }
+}

--- a/backend/Lithuaningo.API/Services/Cache/ICacheService.cs
+++ b/backend/Lithuaningo.API/Services/Cache/ICacheService.cs
@@ -7,4 +7,4 @@ public interface ICacheService
     Task RemoveAsync(string key);
     Task RemoveByPrefixAsync(string prefix);
     Task ClearAllAsync();
-} 
+}

--- a/backend/Lithuaningo.API/Services/Cache/ICacheSettingsService.cs
+++ b/backend/Lithuaningo.API/Services/Cache/ICacheSettingsService.cs
@@ -1,0 +1,7 @@
+namespace Lithuaningo.API.Services.Cache
+{
+    public interface ICacheSettingsService
+    {
+        Task<CacheSettings> GetCacheSettingsAsync();
+    }
+}


### PR DESCRIPTION
- Replaced direct usage of CacheSettings with ICacheSettingsService across various services, including AppInfoService, ChallengeService, FlashcardService, LeaderboardService, and UserProfileService.
- Implemented asynchronous retrieval of cache settings to ensure up-to-date configurations are used for caching operations.
- Enhanced caching logic to improve maintainability and flexibility in cache expiration settings.

These changes aim to streamline cache management and improve the overall performance of the application.