### PR TITLE
Remove Unused Date Properties from Subscription Model

### DIFF
--- a/backend/Lithuaningo.API/Models/Subscription.cs
+++ b/backend/Lithuaningo.API/Models/Subscription.cs
@@ -44,11 +44,5 @@ namespace Lithuaningo.API.Models
 
         [Column("metadata")]
         public object? Metadata { get; set; }
-
-        [Column("created_at")]
-        public DateTime CreatedAt { get; set; }
-
-        [Column("updated_at")]
-        public DateTime UpdatedAt { get; set; }
     }
 }


### PR DESCRIPTION
- Deleted the CreatedAt and UpdatedAt properties from the Subscription model to streamline the codebase and eliminate unnecessary data fields.

This change simplifies the Subscription model, focusing on essential attributes for subscription management.