### PR TITLE
Update Privacy Policy and Terms of Service with new last updated date

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -4,7 +4,7 @@ title: Privacy Policy
 permalink: /privacy-policy/
 ---
 
-Last updated: January 15, 2025
+Last updated: June 15, 2025
 Thank you for choosing Lithuaningo ("us", "we", or "our"). This Privacy Policy explains how we collect, use, and disclose information about you when you use our mobile application ("App").
 
 By using the App, you agree to the collection and use of information in accordance with this Privacy Policy.
@@ -300,7 +300,7 @@ We regularly review and update this policy to reflect:
 - Regulatory requirements
 - Third-party service updates
 
-Last major update: January 15, 2025
+Last major update: June 15, 2025
 
 ## 13. Legal Basis for Processing (GDPR Compliance)
 

--- a/docs/terms-of-service.md
+++ b/docs/terms-of-service.md
@@ -4,7 +4,7 @@ title: Terms of Service
 permalink: /terms-of-service/
 ---
 
-**Last updated: January 15, 2025**
+**Last updated: June 15, 2025**
 
 ## 1. Age Requirements and Eligibility
 

--- a/frontend/src/app/(legal)/privacy-policy.tsx
+++ b/frontend/src/app/(legal)/privacy-policy.tsx
@@ -20,9 +20,7 @@ const PrivacyPolicy = () => {
 
   return (
     <ScrollView>
-      <CustomText {...paragraphProps}>
-        Last updated: January 15, 2025
-      </CustomText>
+      <CustomText {...paragraphProps}>Last updated: June 15, 2025</CustomText>
 
       <CustomText {...paragraphProps}>
         Thank you for choosing Lithuaningo ("us", "we", or "our"). This Privacy

--- a/frontend/src/app/(legal)/terms-of-service.tsx
+++ b/frontend/src/app/(legal)/terms-of-service.tsx
@@ -20,9 +20,7 @@ const TermsOfService = () => {
 
   return (
     <ScrollView>
-      <CustomText {...paragraphProps}>
-        Last updated: January 15, 2025
-      </CustomText>
+      <CustomText {...paragraphProps}>Last updated: June 15, 2025</CustomText>
 
       <CustomText variant="titleMedium" bold>
         1. Age Requirements and Eligibility


### PR DESCRIPTION
- Changed the last updated date in both the Privacy Policy and Terms of Service documents from January 15, 2025, to June 15, 2025.
- Updated corresponding frontend components to reflect the new date.

These changes ensure that users have the most current information regarding our legal documents.